### PR TITLE
README.mdに画面遷移図のリンクを追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Flowque（Flow + Technique）は、ブラジリアン柔術の練習メモを”
 - スニペットフロー作成機能
 - スニペットフロー編集機能
 - スニペットフロー削除機能
-- タグ機能(練度、アクションタイプ別)
 - クイックメモ編集機能
 - お気に入り登録機能
 - お気に入り一覧機能
@@ -65,7 +64,6 @@ Flowque（Flow + Technique）は、ブラジリアン柔術の練習メモを”
 - ゲストログイン機能
 - テクニックノート検索機能（マルチ検索・オートコンプリート）
 - テクニック名オートコンプリート機能
-- タグ別検索機能
 - 多言語(英語)対応
 - PWA対応
 - テクニックノート・スニペットフロー共有機能（要検討）
@@ -86,3 +84,6 @@ Flowque（Flow + Technique）は、ブラジリアン柔術の練習メモを”
 | ノードレイアウト | dagre.js |
 | ノード追加ボタン / 子ノード折りたたみボタン配置 | cytoscape-popper / floating-ui |
 | 認証機能 | Devise / OmniAuth-Google-OAuth2 |
+
+## 画面遷移図
+[Figma - Flowque画面遷移図](https://www.figma.com/design/50XTJ2AdMyuF8x4kjTbcvT/Flowque)


### PR DESCRIPTION
README.mdに画面遷移図のリンクを追記しました。

### 画面遷移図
Figma：https://www.figma.com/design/50XTJ2AdMyuF8x4kjTbcvT/Flowque

### READMEに記載した機能
- [x] ユーザー登録機能
- [x] ログイン機能
- [x] メインフロー表示機能
- [x] フローパーツ表示機能
- [x] テクニックノート編集機能
- [x] メインフロー編集機能
- [x] スニペットフロー作成機能
- [x] スニペットフロー編集機能
- [x] スニペットフロー削除機能
- [x] クイックメモ編集機能
- [x] お気に入り登録機能
- [x] お気に入り一覧機能
- [x] お気に入り解除機能

### 未ログインでも閲覧または利用できるページ
以下の項目は適切に未ログインでも閲覧または利用できる画面遷移になっているか？
- MVPリリース時点ではトップページのみ

### メールアドレス・パスワード変更確認項目
直接変更できるものではなく、一旦メールなどを介して専用のページで変更する画面遷移になっているか？
- Googleアカウントを使ってログインを行う形式とするため、本アプリ上でメールアドレス・パスワードを直接変更することはできない。
  - [x] メールアドレス
  - [x] パスワード

### 各画面の作り込み
画面遷移だけでなく、必要なボタンやフォームが確認できるくらい作り込めているか？
- [x] 作り込みはある程度完了している（Figmaを見て画面の作成ができる状態にある）