### PR TITLE
ノード詳細画面におけるテクニック新規作成機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ erDiagram
 
   techniques {
     int id PK "(NOT NULL)"
-    int user_id FK "ユーザーID (NOT NULL)name"
+    int user_id FK "ユーザーID (NOT NULL)"
     int technique_preset_id FK "プリセットID(NULLならユーザー定義)"
     string name "テクニック名 (プリセット非参照時のみ使用)"
     int category "enumを使い、テクニックのカテゴリーを表現 (プリセット非参照時のみ使用)"

--- a/app/controllers/mypage/nodes_controller.rb
+++ b/app/controllers/mypage/nodes_controller.rb
@@ -34,7 +34,7 @@ class Mypage::NodesController < Mypage::BaseController
     chart = @node.chart
     # technique = @node.technique
 
-    selected_ids = Array(update_params[:children_ids]).compact_blank.map(&:to_i)
+    selected_ids = Array(update_params[:children_ids])
     current_ids = @node.children.pluck(:technique_id)
 
     ids_to_add = selected_ids - current_ids

--- a/app/controllers/mypage/nodes_controller.rb
+++ b/app/controllers/mypage/nodes_controller.rb
@@ -3,19 +3,38 @@ class Mypage::NodesController < Mypage::BaseController
     @chart = current_user.charts.find(params[:chart_id])
     exclude_ids = @chart.nodes.roots.pluck(:technique_id)
     @candidate_techniques = current_user.techniques.where.not(id: exclude_ids)
-    @node = @chart.nodes.build
   end
 
   def create
     @chart = current_user.charts.find(params[:chart_id])
-    @node = @chart.nodes.build(create_params)
 
-    if @node.save
-      redirect_to mypage_chart_path(@chart), notice: "フローの開始点を作成しました"
-    else
-      flash.now[:alert] = "保存できませんでした"
-      render :new, status: :unprocessable_entity
+    roots = Array(create_params[:roots])
+
+    new_names = []
+    existing_ids = []
+
+    roots.each do |root|
+      if root.to_s.start_with?("new: ")
+        new_names << root.sub(/^new: /, "")
+      else
+        existing_ids << root.to_i
+      end
     end
+
+    new_ids = new_names.map do |name|
+      current_user.techniques.create!(name: name).id
+    end
+
+    ids_to_add = existing_ids + new_ids
+
+    ids_to_add.each do |tid|
+      Node.create!(
+        chart: @chart,
+        technique_id: tid
+      )
+    end
+
+    redirect_to mypage_chart_path(@chart), notice: "フローの開始点を作成しました"
   end
 
   def edit
@@ -91,7 +110,7 @@ class Mypage::NodesController < Mypage::BaseController
   private
 
   def create_params
-    params.require(:node).permit(:technique_id)
+    params.require(:node).permit(roots: [])
   end
 
   def update_params

--- a/app/controllers/mypage/nodes_controller.rb
+++ b/app/controllers/mypage/nodes_controller.rb
@@ -34,7 +34,24 @@ class Mypage::NodesController < Mypage::BaseController
     chart = @node.chart
     # technique = @node.technique
 
-    selected_ids = Array(update_params[:children_ids])
+    children_all = Array(update_params[:children_ids])
+
+    new_names = []
+    existing_ids = []
+
+    children_all.each do |child|
+      if child.to_s.start_with?("new: ")
+        new_names << child.sub(/^new: /, "")
+      else
+        existing_ids << child.to_i
+      end
+    end
+
+    new_ids = new_names.map do |name|
+      current_user.techniques.find_or_create_by!(name: name).id
+    end
+
+    selected_ids = existing_ids + new_ids
     current_ids = @node.children.pluck(:technique_id)
 
     ids_to_add = selected_ids - current_ids

--- a/app/controllers/mypage/nodes_controller.rb
+++ b/app/controllers/mypage/nodes_controller.rb
@@ -34,12 +34,12 @@ class Mypage::NodesController < Mypage::BaseController
     chart = @node.chart
     # technique = @node.technique
 
-    children_all = Array(update_params[:children_ids])
+    children = Array(update_params[:children])
 
     new_names = []
     existing_ids = []
 
-    children_all.each do |child|
+    children.each do |child|
       if child.to_s.start_with?("new: ")
         new_names << child.sub(/^new: /, "")
       else
@@ -96,6 +96,6 @@ class Mypage::NodesController < Mypage::BaseController
 
   def update_params
     # 展開先テクニックに何も選択されていない状態で更新をかけるとparams[:node]自体が送られないので、空配列も許容する。
-    params.fetch(:node, {}).permit(children_ids: [])
+    params.fetch(:node, {}).permit(children: [])
   end
 end

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -6,7 +6,12 @@ export default class extends Controller {
   connect() {
 		this.select = new TomSelect(this.element, {
 		  plugins: ['remove_button'],
-      create: false,
+      create: input => {
+				return {
+					value: `new: ${input}`, 
+					text: input
+				};
+		},
       persist: false,
       maxItems: null, 
       placeholder: this.element.getAttribute("placeholder") || ""

--- a/app/views/mypage/nodes/edit.html.erb
+++ b/app/views/mypage/nodes/edit.html.erb
@@ -2,7 +2,8 @@
   <h2 class="text-lg font-bold mb-4">テクニック設定</h2>
 
   <%= form_with model: @technique, url: mypage_technique_path(@technique), method: :patch do |f| %>
-    <!-- リダイレクト先指定のため、techniques_controller へ chart_id を渡す必要がある。-->
+    <!-- リダイレクト先指定のため、techniques_controller へ chart_id を渡す必要がある -->
+    <!-- TODO: このあたりの処理は Formオブジェクト に移したい-->
     <%= hidden_field_tag :chart_id, @chart.id %>
     <%= render 'shared/error_messages', object: @technique %>
     <div class="flex flex-col items-center">

--- a/app/views/mypage/nodes/edit.html.erb
+++ b/app/views/mypage/nodes/edit.html.erb
@@ -15,10 +15,10 @@
   <div class="divider my-8"></div>
 
   <%= form_with model: @node, url: mypage_node_path(@node), method: :patch, class: "space-y-2 w-4/5 mx-auto" do |ff| %>
-    <%= label_tag "node_children_ids", "展開先テクニック" %>
-    <%= select_tag "node[children_ids][]", 
+    <%= label_tag "children_nodes", "展開先テクニック" %>
+    <%= select_tag "node[children][]", 
             options_from_collection_for_select(@candidate_techniques + @children.map(&:technique), :id, :name, @children.pluck(:technique_id)),
-            id: "node_children_ids",
+            id: "children_nodes",
             multiple: true,
             placeholder: "テクニックを検索",
             data: { controller: "tom-select" }

--- a/app/views/mypage/nodes/new.html.erb
+++ b/app/views/mypage/nodes/new.html.erb
@@ -1,13 +1,14 @@
 <%= turbo_frame_tag "node-drawer" do %>
-  <h2 class="text-lg font-bold mb-4">フロー新規作成</h2>
+  <h2 class="text-lg font-bold mb-4">フローの開始点を新規作成</h2>
 
-  <%= form_with model: @node, url: mypage_chart_nodes_path(@chart), method: :post, class: "space-y-2 mt-10 w-4/5 mx-auto" do |f| %>
-    <%= label_tag "technique_id", "テクニックを選択" %>
-    <%= select_tag "node[technique_id]", 
+  <%= form_with url: mypage_chart_nodes_path(@chart), method: :post, class: "space-y-2 mt-10 w-4/5 mx-auto" do |f| %>
+    <%= label_tag "root_nodes", "テクニックを選択" %>
+    <%= select_tag "node[roots]", 
             options_from_collection_for_select(@candidate_techniques, :id, :name),
-            id: "technique_id",
+            multiple: true,
+            id: "root_nodes",
             placeholder: "選択してください",
-            class: "select"
+            data: { controller: "tom-select" }
     %>
 
     <div class="flex justify-center">


### PR DESCRIPTION
close #100

##### 改修前：
チャート画面からアクセスできるノード詳細画面で、既存の展開先テクニックしか選べなかった。
##### 改修後：
ノード詳細画面の展開先テクニックフォームから、テクニックを新規作成した上で、それを展開先テクニックとして選択できるようにした。