### PR TITLE
Chore/misc update

### DIFF
--- a/app/controllers/api/v1/charts_controller.rb
+++ b/app/controllers/api/v1/charts_controller.rb
@@ -1,6 +1,4 @@
 class Api::V1::ChartsController < ApplicationController
-  before_action :authenticate_user!
-
   def show
     nodes = current_user.charts.first.nodes
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+  before_action :authenticate_user!
 
   def after_sign_in_path_for(resource)
     mypage_root_path

--- a/app/controllers/mypage/base_controller.rb
+++ b/app/controllers/mypage/base_controller.rb
@@ -1,5 +1,0 @@
-module Mypage
-  class BaseController < ApplicationController
-    before_action :authenticate_user!
-  end
-end

--- a/app/controllers/mypage/charts_controller.rb
+++ b/app/controllers/mypage/charts_controller.rb
@@ -1,4 +1,4 @@
-class Mypage::ChartsController < Mypage::BaseController
+class Mypage::ChartsController < ApplicationController
   def show
     @chart = current_user.charts.first
   end

--- a/app/controllers/mypage/menu_controller.rb
+++ b/app/controllers/mypage/menu_controller.rb
@@ -1,4 +1,4 @@
-class Mypage::MenuController < Mypage::BaseController
+class Mypage::MenuController < ApplicationController
   def show
     @chart = current_user.charts.first
   end

--- a/app/controllers/mypage/nodes_controller.rb
+++ b/app/controllers/mypage/nodes_controller.rb
@@ -1,4 +1,4 @@
-class Mypage::NodesController < Mypage::BaseController
+class Mypage::NodesController < ApplicationController
   def new
     @chart = current_user.charts.find(params[:chart_id])
     exclude_ids = @chart.nodes.roots.pluck(:technique_id)

--- a/app/controllers/mypage/techniques_controller.rb
+++ b/app/controllers/mypage/techniques_controller.rb
@@ -1,4 +1,4 @@
-class Mypage::TechniquesController < Mypage::BaseController
+class Mypage::TechniquesController < ApplicationController
   def index
     @techniques = current_user.techniques
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
 class PagesController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def top; end
 end

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -13,68 +13,71 @@ export default class extends Controller {
 		addUrl: String
 	}
 
-  connect() {
+	connect() {
 		const url = this.fetchUrlValue;
 		console.log(this.element.dataset)
-    fetch(url)
-      .then((response) => response.json())
-      .then((elements_data) => {
-        this.cy = cytoscape({
-          container: this.cyTarget,
-          autoungrabify: true,
-          elements: elements_data,
-          style: [
-            {
-              selector: "node",
-              style: {
-                shape: "ellipse",
-                width: 1,
-                height: 1,
-                "background-color": "#FFF",
-                label: "data(label)",
-                "text-valign": "top",
-                "text-halign": "center",
-                color: "#333333", // #505050 はやわらかめの黒
-                "font-size": "4px",
-                padding: "4px",
-                "border-width": 0.5,
-                "border-color": "#b1b1b6",
-                "border-style": "solid",
-                "border-cap": "square",
-              },
-            },
-            {
-              selector: "edge",
-              style: {
-                "curve-style": "round-taxi",
-                width: 0.5,
-                "line-color": "#b1b1b6", // #7570B3 は柔らかい紫
-                "target-arrow-shape": "triangle",
-                "arrow-scale": 0.2,
-                "taxi-radius": 3,
-                "taxi-turn": "20px", // 曲がり角の位置として、ソースノードからの絶対距離を指定する（指定しないとソースノードとターゲットノードの相対距離によって位置算出が行われるらしく、同列ノードの曲がり角の位置がズレる）
-              },
-            },
-          ],
-          layout: {
-            name: "dagre",
-            rankDir: "LR",
-            nodeSep: 10,
-            edgeSep: 10,
-            ranker: "tight-tree",
-          },
-        });
+		fetch(url)
+			.then((response) => response.json())
+			.then((elements_data) => {
+				this.cy = cytoscape({
+				container: this.cyTarget,
+				autoungrabify: true,
+				elements: elements_data,
+				style: [
+					{
+						selector: "node",
+						style: {
+							shape: "ellipse",
+							width: 1,
+							height: 1,
+							"background-color": "#FFF",
+							label: "data(label)",
+							"text-valign": "top",
+							"text-halign": "center",
+							color: "#333333", // #505050 はやわらかめの黒
+							"font-size": "4px",
+							padding: "4px",
+							"border-width": 0.5,
+							"border-color": "#b1b1b6",
+							"border-style": "solid",
+							"border-cap": "square",
+					},
+					},
+					{
+						selector: "edge",
+						style: {
+							"curve-style": "round-taxi",
+							width: 0.5,
+							"line-color": "#b1b1b6", // #7570B3 は柔らかい紫
+							"target-arrow-shape": "triangle",
+							"arrow-scale": 0.2,
+							"taxi-radius": 3,
+							"taxi-turn": "20px", // 曲がり角の位置として、ソースノードからの絶対距離を指定する（指定しないとソースノードとターゲットノードの相対距離によって位置算出が行われるらしく、同列ノードの曲がり角の位置がズレる）
+						},
+					},
+				],
+		layout: {
+			name: "dagre",
+			 rankDir: "LR",
+			nodeSep: 10,
+			edgeSep: 10,
+			ranker: "tight-tree",
+					},
+				});
 
-        this.cy.on("tap", "node", (evt) => {
-          const node = evt.target;
-          this.openDrawer(node.data());
-        });
+				this.cy.on("tap", "node", (evt) => {
+					const node = evt.target;
+					this.openDrawer(node.data());
+				});
 
 				this.cy.on("tap", (evt) => {
 					if (evt.target == this.cy) {
 						this.closeDrawer()
 					}
 				});
+
+				this.cy.fit(this.cy.elements(), 50);          // 好きな初期表示
+				this.cy.minZoom(this.cy.zoom() * 0.5);             // これ以下にズームアウト不可（迷子防止）
       })
   }
 

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -3,20 +3,20 @@ import TomSelect from "tom-select"
 
 // Connects to data-controller="tom-select"
 export default class extends Controller {
-  connect() {
+	connect() {
 		this.select = new TomSelect(this.element, {
-		  plugins: ['remove_button'],
-      create: input => {
+			plugins: ['remove_button'],
+  		create: input => {
 				return {
 					value: `new: ${input}`, 
 					text: input
 				};
 		},
-      persist: false,
-      maxItems: null, 
-      placeholder: this.element.getAttribute("placeholder") || ""
+			persist: false,
+			maxItems: null, 
+			placeholder: this.element.getAttribute("placeholder") || ""
 		})
-  }
+	}
 	disconnect(){
 		this.select?.destroy()
 	}

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -4,3 +4,4 @@ bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate
+bundle exec rails db:seed

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,131 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+# enum :category, { submission: 0, sweep: 1, pass: 2, guard: 3, control: 4,  takedown: 5 }
+
+techniques = [
+
+  # ========================
+  # SUBMISSIONS
+  # ========================
+  { name_ja: "腕十字固め", name_en: "Armbar", category: :submission },
+  { name_ja: "三角絞め", name_en: "Triangle Choke", category: :submission },
+  { name_ja: "オモプラッタ", name_en: "Omoplata", category: :submission },
+  { name_ja: "ギロチンチョーク", name_en: "Guillotine Choke", category: :submission },
+  { name_ja: "裸絞め", name_en: "Rear Naked Choke", category: :submission },
+  { name_ja: "袖車絞め", name_en: "Ezekiel Choke", category: :submission },
+  { name_ja: "アメリカーナ", name_en: "Americana", category: :submission },
+  { name_ja: "キムラロック", name_en: "Kimura Lock", category: :submission },
+  { name_ja: "アンクルロック", name_en: "Straight Ankle Lock", category: :submission },
+  { name_ja: "ヒールフック", name_en: "Heel Hook", category: :submission },
+  { name_ja: "カーフスライサー", name_en: "Calf Slicer", category: :submission },
+  { name_ja: "リストロック", name_en: "Wrist Lock", category: :submission },
+  { name_ja: "ボーアンドアローチョーク", name_en: "Bow and Arrow Choke", category: :submission },
+  { name_ja: "クロスカラー絞め", name_en: "Cross Collar Choke", category: :submission },
+  { name_ja: "ループチョーク", name_en: "Loop Choke", category: :submission },
+  { name_ja: "ペーパーカッターチョーク", name_en: "Paper Cutter Choke", category: :submission },
+  { name_ja: "ノースサウスチョーク", name_en: "North-South Choke", category: :submission },
+  { name_ja: "ベースボールチョーク", name_en: "Baseball Bat Choke", category: :submission },
+  { name_ja: "後ろ三角締め", name_en: "Back Triangle", category: :submission },
+  { name_ja: "ダースチョーク", name_en: "D'Arce Choke", category: :submission },
+  { name_ja: "アナコンダチョーク", name_en: "Anaconda Choke", category: :submission },
+  { name_ja: "コムロック", name_en: "Komu-Lock", category: :submission },
+  { name_ja: "カントチョーク", name_en: "Canto Choke", category: :submission },
+
+  # ========================
+  # SWEEPS
+  # ========================
+  { name_ja: "アンストッパブルスイープ", name_en: "Unstoppable Sweep", category: :sweep },
+  { name_ja: "シザースイープ", name_en: "Scissor Sweep", category: :sweep },
+  { name_ja: "フラワースイープ", name_en: "Flower Sweep", category: :sweep },
+  { name_ja: "エレベータースイープ", name_en: "Elevator Sweep", category: :sweep },
+  { name_ja: "ヒップバンプスイープ", name_en: "Hip Bump Sweep", category: :sweep },
+  { name_ja: "巴投げ", name_en: "Tomoe Nage", category: :sweep },
+  { name_ja: "シットアップスイープ", name_en: "Sit-up Sweep", category: :sweep },
+  { name_ja: "ベリンボロ", name_en: "Berimbolo", category: :sweep },
+  { name_ja: "Xガードスイープ", name_en: "X-Guard Sweep", category: :sweep },
+  { name_ja: "ラッソースイープ", name_en: "Lasso Sweep", category: :sweep },
+  { name_ja: "デラヒーバスイープ", name_en: "De La Riva Sweep", category: :sweep },
+  { name_ja: "シントゥシンスイープ", name_en: "Shin-to-Shin Sweep", category: :sweep },
+  { name_ja: "バタフライスイープ", name_en: "Butterfly Sweep", category: :sweep },
+  { name_ja: "キスオブザドラゴン", name_en: "Kiss of the Dragon", category: :sweep },
+  { name_ja: "ヒップスロー", name_en: "Hip Throw", category: :sweep },
+  { name_ja: "草刈りスイープ", name_en: "Tripod Sweep", category: :sweep },
+  { name_ja: "マッスルスイープ", name_en: "Muscle Sweep", category: :sweep },
+  { name_ja: "フックスイープ", name_en: "Hook Sweep", category: :sweep },
+
+  # ========================
+  # PASS
+  # ========================
+  { name_ja: "トレアドールパス", name_en: "Toreando Pass", category: :pass },
+  { name_ja: "オーバーアンダーパス", name_en: "Over-Under Pass", category: :pass },
+  { name_ja: "スタックパス", name_en: "Stack Pass", category: :pass },
+  { name_ja: "スマッシュパス", name_en: "Smash Pass", category: :pass },
+  { name_ja: "ダブルアンダーパス", name_en: "Double Under Pass", category: :pass },
+  { name_ja: "Xパス", name_en: "X-Pass", category: :pass },
+  { name_ja: "サイドスイッチパス", name_en: "Side Switch Pass", category: :pass },
+  { name_ja: "ロングステップパス", name_en: "Long Step Pass", category: :pass },
+  { name_ja: "ニースライスパス", name_en: "Knee Slice Pass", category: :pass },
+  { name_ja: "レッグドラッグパス", name_en: "Leg Drag Pass", category: :pass },
+
+  # ========================
+  # GUARD
+  # ========================
+  { name_ja: "クローズドガード", name_en: "Closed Guard", category: :guard },
+  { name_ja: "片襟片袖ガード", name_en: "Collar Sleeve Guard", category: :guard },
+  { name_ja: "オープンガード", name_en: "Open Guard", category: :guard },
+  { name_ja: "スパイダーガード", name_en: "Spider Guard", category: :guard },
+  { name_ja: "デラヒーバガード", name_en: "De La Riva Guard", category: :guard },
+  { name_ja: "リバースデラヒーバ", name_en: "Reverse De La Riva", category: :guard },
+  { name_ja: "ハーフガード", name_en: "Half Guard", category: :guard },
+  { name_ja: "ディープハーフ", name_en: "Deep Half Guard", category: :guard },
+  { name_ja: "バタフライガード", name_en: "Butterfly Guard", category: :guard },
+  { name_ja: "ラッソーガード", name_en: "Lasso Guard", category: :guard },
+  { name_ja: "シャローラッソーガード", name_en: "Shallow Lasso Guard", category: :guard },
+  { name_ja: "Xガード", name_en: "X-Guard", category: :guard },
+  { name_ja: "ワームガード", name_en: "Worm Guard", category: :guard },
+  { name_ja: "スクイッドガード", name_en: "Squid Guard", category: :guard },
+  { name_ja: "オクトパスガード", name_en: "Octopus Guard", category: :guard },
+  { name_ja: "リングワームガード", name_en: "Ringworm Guard", category: :guard },
+  { name_ja: "Kガード", name_en: "K-Guard", category: :guard },
+  { name_ja: "Zガード", name_en: "Z-Guard", category: :guard },
+  { name_ja: "50/50ガード", name_en: "50/50 Guard", category: :guard },
+  { name_ja: "クォーターガード", name_en: "Quarter Guard", category: :guard },
+  { name_ja: "シッティングガード", name_en: "Seated Guard", category: :guard },
+  { name_ja: "ワンレッグXガード", name_en: "Single Leg X-Guard", category: :guard },
+  { name_ja: "ウェイターガード", name_en: "Waiter Guard", category: :guard },
+  { name_ja: "レーザーガード", name_en: "Laser Guard", category: :guard },
+
+  # ========================
+  # CONTROL
+  # ========================
+  { name_ja: "マウント", name_en: "Mount", category: :control },
+  { name_ja: "S字マウント", name_en: "S-Mount", category: :control },
+  { name_ja: "サイドコントロール", name_en: "Side Control", category: :control },
+  { name_ja: "ニーオンベリー", name_en: "Knee on Belly", category: :control },
+  { name_ja: "バックコントロール", name_en: "Back Control", category: :control },
+  { name_ja: "ノースサウス", name_en: "North-South", category: :control },
+  { name_ja: "袈裟固め", name_en: "Kesa Gatame", category: :control },
+  { name_ja: "後ろ袈裟固め", name_en: "Reverse Kesa Gatame", category: :control },
+
+  # ========================
+  # TAKEDOWNS
+  # ========================
+  { name_ja: "ダブルレッグテイクダウン", name_en: "Double Leg Takedown", category: :takedown },
+  { name_ja: "シングルレッグテイクダウン", name_en: "Single Leg Takedown", category: :takedown },
+  { name_ja: "アンクルピックテイクダウン", name_en: "Ankle Pick Takedown", category: :takedown },
+  { name_ja: "背負い投げ", name_en: "Seoi Nage", category: :takedown },
+  { name_ja: "小内刈り", name_en: "Kouchi Gari", category: :takedown },
+  { name_ja: "足払い", name_en: "Foot Sweep", category: :takedown },
+  { name_ja: "アームドラッグタックル", name_en: "Arm Drag Takedown", category: :takedown }
+]
+
+techniques.each do |attrs|
+  preset = TechniquePreset.find_or_initialize_by(name_en: attrs[:name_en])
+  preset.name_ja = attrs[:name_ja]
+  preset.category = TechniquePreset.categories[attrs[:category]]
+  preset.save!
+end
+
+puts "✅ #{techniques.size} techniques seeded."


### PR DESCRIPTION
## close #59
再現が取れる形で、ユーザーが所有するtechniquesのテンプレートとなるtechnique_presetsテーブルのデータを更新できるようにした（ビルド時のスクリプトに`rails db:seed`の記述を含めれば、technique_presetsテーブルにseeds.rbの内容が反映されるようにした）。
なお、繰り返し`rails db:seed`を実行してもデータが重複して登録されないようになっている。
## close #96 
### 
ログインが前提となる機能が多いアプリケーションの場合、ApplicationControllerにユーザー認証必須コールバック関数を仕込む方が保守性が高い考え、Mypage::BaseControllerに置いていた`before_action :authenticate_user!`をApplicationControllerに移した。