### PR TITLE
バグの修正3点

### DIFF
--- a/app/controllers/api/v1/charts_controller.rb
+++ b/app/controllers/api/v1/charts_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::ChartsController < ApplicationController
     nodes = current_user.charts.first.nodes
 
     nodes_data = nodes.map do |node|
-      { data: { id: node.id.to_s, label: node.technique.name } }
+      { data: { id: node.id.to_s, label: node.technique.name_ja, category: node.technique.category } }
     end
 
     edges_data = nodes.map do |node|

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
 
     <link rel="manifest" href="/manifest.json">
     <%= favicon_link_tag 'flow-tracker-logo.png', rel: 'apple-touch-icon', type: 'image/png' %>
-    <%= favicon_link_tag 'flow-tracker-logo.svg' %>　
+    <%= favicon_link_tag 'flow-tracker-logo.svg' %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>

--- a/app/views/mypage/charts/show.html.erb
+++ b/app/views/mypage/charts/show.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="drawer drawer-end min-h-screen px-4 py-6 bg-base-100 space-y-6"
+  class="drawer drawer-end px-4 py-6 bg-base-100 space-y-6"
   data-controller="step-guide chart"
   data-action="step-guide:openNode->chart#forStepGuide"
   data-chart-fetch-url-value="<%= api_v1_chart_path(@chart) %>"
@@ -7,7 +7,7 @@
   data-chart-add-url-value="<%= new_mypage_chart_node_path(@chart) %>"
 >
   <input type="checkbox" class="drawer-toggle" data-chart-target="toggle" />
-  <div class="drawer-content">
+  <div class="drawer-content flex flex-col min-h-screen">
     <div class="flex items-center space-x-2 m-4">
       <h1 class="text-3xl font-bold ml-8">Flow Chart</h1>
       <div class="tooltip" data-tip="ステップガイドを開始するにはここをクリック" data-action="click->step-guide#startChartGuide">
@@ -18,18 +18,20 @@
     </div>
 
     <div id="step0" class="hidden" data-intro-text="こちらは、テクニック同士の繋がりを可視化するための画面です。<br><br>このエリアにテクニックを配置し、フローチャートを作ることができます。"></div>
-  
-    <div data-chart-target="cy" class="h-screen mx-auto w-9/10 border border-gray-300">
-      <!-- z-1を使ってcyコンテナより手前に出しておかないとボタンが効かなくなる -->
+
+    <div class="mx-auto w-[90%] border border-base-300 relative flex-1 min-h-0">
+    <!-- z-1を使ってcyコンテナより手前に出しておかないとボタンが効かなくなる -->
       <button
         id="step1"
         type="button"
-        class="btn btn-primary btn-wide absolute top-6 left-6 z-1" 
+        class="btn btn-primary btn-wide absolute top-4 left-4 z-1" 
         data-action="click->chart#addNode"
         data-title-text="新規作成"
         data-intro-text="ここからフローチャートの開始点(ルートノード)を新規作成できます。">
         新しいフローを作る
       </button>
+      <!-- チャート描写用コンテナ -->
+      <div data-chart-target="cy" class="h-full"></div>
     </div>
   </div>
 

--- a/app/views/mypage/nodes/edit.html.erb
+++ b/app/views/mypage/nodes/edit.html.erb
@@ -41,7 +41,7 @@
   %>
     <%= label_tag "children_nodes", "展開先テクニック" %>
     <%= select_tag "node[children][]", 
-            options_from_collection_for_select(@candidate_techniques + @children.map(&:technique), :id, :name, @children.pluck(:technique_id)),
+            options_from_collection_for_select(@candidate_techniques + @children.map(&:technique), :id, :name_ja, @children.pluck(:technique_id)),
             id: "children_nodes",
             multiple: true,
             placeholder: "テクニックを検索",

--- a/app/views/mypage/nodes/new.html.erb
+++ b/app/views/mypage/nodes/new.html.erb
@@ -4,7 +4,7 @@
   <%= form_with url: mypage_chart_nodes_path(@chart), method: :post, class: "space-y-2 mt-10 w-4/5 mx-auto" do |f| %>
     <%= label_tag "root_nodes", "テクニックを選択" %>
     <%= select_tag "node[roots]", 
-            options_from_collection_for_select(@candidate_techniques, :id, :name),
+            options_from_collection_for_select(@candidate_techniques, :id, :name_ja),
             multiple: true,
             id: "root_nodes",
             placeholder: "選択してください",


### PR DESCRIPTION
## 修正したバグ
- ヘッダー上に意図しない空白エリアが発生(ファビコン記述末尾に全角スペースが挿入されていたことが原因)
- 新しいフローを作るボタンがチャート画面タイトルと被った位置に描写される(チャート描写コンテナにボタンを内包していたことが原因)
- チャート画面にてドロワーの中身が表示されない(techniquesテーブルにて、`name`→`name_ja`+`nane_en`にカラム名を変更したのに関わらず、フォームで引き続き前者を使用していたことが原因)