### PR TITLE
チャートデザイン改修＋バグ修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,8 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
-  before_action :authenticate_user!, if: :user_signed_in?
-  before_action :set_chart
+  before_action :authenticate_user!
+  before_action :set_chart, if: :user_signed_in?
 
   private
 

--- a/app/controllers/custom_failure.rb
+++ b/app/controllers/custom_failure.rb
@@ -1,0 +1,7 @@
+class CustomFailure < Devise::FailureApp
+  private
+    # ログインしていない状態で要ログインページにアクセスした際のリダイレクト先指定
+    def redirect_url
+      root_path
+    end
+end

--- a/app/controllers/mypage/nodes_controller.rb
+++ b/app/controllers/mypage/nodes_controller.rb
@@ -22,7 +22,7 @@ class Mypage::NodesController < ApplicationController
     end
 
     new_ids = new_names.map do |name|
-      current_user.techniques.create!(name: name).id
+      current_user.techniques.create!(name_ja: name, name_en: name).id
     end
 
     ids_to_add = existing_ids + new_ids
@@ -46,6 +46,12 @@ class Mypage::NodesController < ApplicationController
     siblings = @node.siblings.includes(:technique)
     exclude_ids = [ @technique.id ] + @children.pluck(:technique_id) + siblings.pluck(:technique_id)
     @candidate_techniques = current_user.techniques.where.not(id: exclude_ids)
+
+    @selected_ids = @children.pluck(:technique_id)
+    @grouped =
+      (@candidate_techniques + @children.map(&:technique))
+        .group_by { |t| t.category ? t.category.humanize : "未分類" }
+        .transform_values { |arr| arr.map { |t| [ t.name_ja, t.id ] } }
   end
 
   def update
@@ -67,7 +73,7 @@ class Mypage::NodesController < ApplicationController
     end
 
     new_ids = new_names.map do |name|
-      current_user.techniques.find_or_create_by!(name: name).id
+      current_user.techniques.find_or_create_by!(name_ja: name, name_en: name).id
     end
 
     selected_ids = existing_ids + new_ids

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -41,15 +41,58 @@ export default class extends Controller {
 							"border-color": "#b1b1b6",
 							"border-style": "solid",
 							"border-cap": "square",
+							},
 					},
+					{
+						selector: "node[category = 'submission']",
+						style: {
+							"background-color": "#F28B82",
+							"border-width": 0,
+							},
+					},
+					{
+						selector: "node[category = 'sweep']",
+						style: {
+							"background-color": "#81D4FA",
+							"border-width": 0,
+							},
+					},
+					{
+						selector: "node[category = 'pass']",
+						style: {
+							"background-color": "#A5D6A7",
+							"border-width": 0,
+							},
+					},
+					{
+						selector: "node[category = 'guard']",
+						style: {
+							"background-color": "#90A4AE",
+							"border-width": 0,
+							},
+					},
+					{
+						selector: "node[category = 'control']",
+						style: {
+							"background-color": "#CE93D8",
+							"border-width": 0,
+							},
+					},
+					{
+						selector: "node[category = 'takedown']",
+						style: {
+							"background-color": "#FFB74D",
+							"border-width": 0,
+							},
 					},
 					{
 						selector: "edge",
 						style: {
 							"curve-style": "round-taxi",
-							width: 0.5,
-							"line-color": "#b1b1b6", // #7570B3 は柔らかい紫
-							"target-arrow-shape": "triangle",
+							width: 0.2,
+							"line-color": "#333333", // #7570B3 は柔らかい紫
+							// "target-arrow-shape": "triangle",
+							// "target-arrow-color": "#333333",
 							"arrow-scale": 0.2,
 							"taxi-radius": 3,
 							"taxi-turn": "20px", // 曲がり角の位置として、ソースノードからの絶対距離を指定する（指定しないとソースノードとターゲットノードの相対距離によって位置算出が行われるらしく、同列ノードの曲がり角の位置がズレる）

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -14,6 +14,7 @@ export default class extends Controller {
 		},
 			persist: false,
 			maxItems: null, 
+			maxOptions: null,
 			placeholder: this.element.getAttribute("placeholder") || ""
 		})
 	}

--- a/app/views/mypage/nodes/edit.html.erb
+++ b/app/views/mypage/nodes/edit.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "node-drawer" do %>
   <div class="flex items-center mb-4">
     <h2 class="text-lg font-bold mr-2">ノード編集</h2>
-    <div class="tooltip tooltip-right" data-tip="ステップガイドを開始するにはここをクリック" data-action="click->step-guide#startNodeGuide">
+    <div class="tooltip tooltip-bottom" data-tip="ステップガイドを開始するにはここをクリック" data-action="click->step-guide#startNodeGuide">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
       </svg>

--- a/app/views/mypage/nodes/edit.html.erb
+++ b/app/views/mypage/nodes/edit.html.erb
@@ -39,13 +39,14 @@
               intro_text: "このテクニックから展開される技を編集することができます。<br><br>ここで展開先として選択されたテクニックは、このテクニックの右側に接続される形でチャート上に描写されます。"
             } do |ff|
   %>
+
     <%= label_tag "children_nodes", "展開先テクニック" %>
-    <%= select_tag "node[children][]", 
-            options_from_collection_for_select(@candidate_techniques + @children.map(&:technique), :id, :name_ja, @children.pluck(:technique_id)),
-            id: "children_nodes",
-            multiple: true,
-            placeholder: "テクニックを検索",
-            data: { controller: "tom-select" }
+    <%= select_tag "node[children][]",
+          grouped_options_for_select(@grouped, @selected_ids),
+          id: "children_nodes",
+          multiple: true,
+          placeholder: "テクニックを検索",
+          data: { controller: "tom-select" }
     %>
 
     <div class="flex justify-center">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -286,6 +286,10 @@ Devise.setup do |config|
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
 
+  config.warden do |manager|
+     manager.failure_app = CustomFailure
+  end
+
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.


### PR DESCRIPTION
## close #114
チャート上でテクニックカテゴリーの見分けがつけやすいよう、ノードに色をつけるようにしました。

## そのほか修正
- ログイン前に要ログインページへアクセスしようとした場合は、ホーム画面にリダイレクトされるようにしました。
- 子ノード追加時、選択肢がテクニックカテゴリーでグループ化された状態で表示されるようにしました。
- 子ノード追加時に表示される選択肢の上限が50となっていたため、これを無制限にしました。